### PR TITLE
examples: add the SDP of a real ST2110 sender

### DIFF
--- a/examples/st2110_sender.sdp
+++ b/examples/st2110_sender.sdp
@@ -1,0 +1,29 @@
+v=0
+o=- 1443716955 1443716955 IN IP4 192.168.39.13
+s=st2110 0-0-0
+t=0 0
+
+m=video 20000 RTP/AVP 96
+c=IN IP4 239.0.0.13/64
+a=source-filter: incl IN IP4 239.0.0.13 192.168.39.1
+a=rtpmap:96 raw/90000
+a=fmtp:96 sampling=YCbCr-4:2:2; width=1920; height=1080; exactframerate=30000/1001; depth=10; TCS=SDR; colorimetry=BT709; PM=2110GPM; SSN=ST2110-20:2017; TP=2110TPN; interlace;
+a=mediaclk:direct=0
+a=ts-refclk:ptp=IEEE1588-2008:74-83-ef-ff-ff-00-a6-ed:127
+
+m=audio 20000 RTP/AVP 97
+c=IN IP4 239.0.1.13/64
+a=source-filter: incl IN IP4 239.0.1.13 192.168.39.1
+a=rtpmap:97 L24/48000/16
+a=mediaclk:direct=0 rate=48000
+a=framecount:6
+a=ptime:0.125
+a=ts-refclk:ptp=IEEE1588-2008:74-83-ef-ff-ff-00-a6-ed:127
+
+m=video 20000 RTP/AVP 100
+c=IN IP4 239.0.17.13/64
+a=source-filter: incl IN IP4 239.0.17.13 192.168.39.1
+a=rtpmap:100 smpte291/90000
+a=fmtp:100 VPID_Code=133;
+a=mediaclk:direct=0 rate=90000
+a=ts-refclk:ptp=IEEE1588-2008:74-83-ef-ff-ff-00-a6-ed:127


### PR DESCRIPTION
It includes video, audio and ancillary essences.