### PR TITLE
rfc4566: allow 's= ' as noted whitespace exception in section 5.3

### DIFF
--- a/checkRFC4566.js
+++ b/checkRFC4566.js
@@ -16,7 +16,7 @@
 const concat = arrays => Array.prototype.concat.apply([], arrays);
 
 const badEndings = /[^\r]\n|\r[^\n]/;
-const linePattern = /^[a-z]=\S.*$/;
+const linePattern = /^([a-z]=\S.*|s= )$/;
 const letterCheck = /^[vosiuepcbzkatrm].*$/;
 // const spaceCheck = /\s\s/;
 const mustHaves = [ 'v', 'o', 's', 't' ];


### PR DESCRIPTION
This is intended to resolve #11 

It covers the 's= ' case only as this is explicitly called out in RFC4566.