### PR TITLE
Add option to fail files which do not include any media descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ The parameters of the library are binary flags that match the command line optio
 * `whitespace`: Strict check of adherence to whitespace rules.
 * `should`: As well as shall, also check all should clauses.
 * `noCopy`: Fail obvious copies of the ST 2110-10 SDP example.
+* `noMedia`: Fail SDP files which do not include any media descriptions.
 * `duplicate`: Expect duplicate streams aka ST 2022-7.
 * `videoOnly`: Describes only SMPTE ST 2110-20 streams.
 * `audioOnly`: Describes only SMPTE ST 2110-30 streams.

--- a/checkRFC4566.js
+++ b/checkRFC4566.js
@@ -327,8 +327,24 @@ const section_57 = (sdp, params) => {
   return concat(tests.map(s => s(sdp, params)));
 };
 
+// Test if SDP file is missing media descriptions
+const no_media = sdp => {
+  let lines = splitLines(sdp.trim());
+  let hasMedia = false;
+  for ( let x = 0 ; x < lines.length ; x++ ) {
+    if (lines[x].startsWith('m=')) {
+      hasMedia = true;
+      break;
+    }
+  }
+  return hasMedia ? [] : [ new Error('SDP file does not include any "m=" media attributes.') ];
+};
+
 const allSections = (sdp, params) => {
   let sections = [ section_50, section_51, section_52, section_57 ];
+  if (params.noMedia) {
+    sections.push(no_media);
+  }
   return concat(sections.map(s => s(sdp, params)));
 };
 

--- a/sdpoker.js
+++ b/sdpoker.js
@@ -25,6 +25,7 @@ const args = yargs
   .default('whitespace', false)
   .default('should', false)
   .default('noCopy', true)
+  .default('noMedia', true)
   .default('duplicate', false)
   .default('videoOnly', false)
   .default('audioOnly', false)
@@ -34,8 +35,8 @@ const args = yargs
   .default('multicast', false)
   .default('unicast', false)
   .default('shaping', false)
-  .boolean([ 'nmos', 'checkEndings', 'whitespace', 'should', 'noCopy', 'duplicate',
-    'videoOnly', 'audioOnly', 'channelOrder',
+  .boolean([ 'nmos', 'checkEndings', 'whitespace', 'should', 'noCopy', 'noMedia',
+    'duplicate', 'videoOnly', 'audioOnly', 'channelOrder',
     'useIP4', 'useIP6', 'multicast', 'unicast', 'shaping' ])
   .usage('Check an SDP file for conformance with RFC4566 and SMPTE ST 2110.\n' +
     'Usage: $0 [options] <sdp_file or HTTP URL>')
@@ -44,6 +45,7 @@ const args = yargs
   .describe('whitespace', 'Strict check of adherence to whitespace rules.')
   .describe('should', 'As well as shall, also check all should clauses.')
   .describe('noCopy', 'Fail obvious copies of the ST 2110-10 SDP example')
+  .describe('noMedia', 'Fail SDP files which do not include any media descriptions')
   .describe('duplicate', 'Expect duplicate streams aka ST 2022-7.')
   .describe('videoOnly', 'Describes only SMPTE ST 2110-20 streams.')
   .describe('audioOnly', 'Describes only SMPTE ST 2110-30 streams.')


### PR DESCRIPTION
This PR adds an additional optional check for whether there are any 'm=' media sections in the SDP file. Whilst RFC 4566 allows for there to be zero of these sections, that would be unusual in a running system. This would catch error cases we have observed at testing events.