### PR TITLE
Remove nmos references to match IS-04 v1.3 and IS-05

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ const { getSDP, checkRFC4566, checkST2110 } = require('sdpoker');
 
 ### Get SDP
 
-The `getSDP(path, nmos)` method returns a native promise to read or download an SDP file from the given path. If the path starts with `http://`, the SDP file is requested from the given address. Otherwise, the path is treated as a file path related to the current working directory.
+The `getSDP(path)` method returns a native promise to read or download an SDP file from the given path. If the path starts with `http://`, the SDP file is requested from the given address. Otherwise, the path is treated as a file path related to the current working directory.
 
 For example:
 
@@ -53,8 +53,6 @@ getSDP('http://localhost:3123/sdps/video_stream_1.sdp')
   .then(console.log)
   .catch(console.error);
 ```
-
-If the `nmos` flag is set to `true`, the SDP file is required to be retrieved over HTTP and must have filename extension `.sdp`.
 
 The value of a fulfilled promise is the contents of an SDP file as a string. SDP files are assumed to be UTF8 character sets. Pass the result into the `checkRFC4566` and `checkST2110` methods.
 
@@ -98,7 +96,6 @@ The return value of the method is an array of [Javascript Errors](https://develo
 
 The parameters of the library are binary flags that match the command line options:
 
-* `nmos`: Check for compliance with NMOS rules.
 * `checkEndings`: Check line endings are CRLF, no other CR/LF.
 * `whitespace`: Strict check of adherence to whitespace rules.
 * `should`: As well as shall, also check all should clauses.
@@ -117,7 +114,6 @@ By default, all flags are `false`. To pass the parameters to the _check_ methods
 
 ```javascript
 let params = {
-  nmos: true,
   duplicate: true,
   multicast: true
 };

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ const readFile = util.promisify(fs.readFile);
 const { allSections : checkRFC4566 } = require('./checkRFC4566.js');
 const { allSections : checkST2110 } = require('./checkST2110.js');
 
-const getSDP = (path, nmos = true) => {
+const getSDP = (path) => {
   return (path.startsWith('http')) ?
     request({
       url: path,
@@ -30,10 +30,7 @@ const getSDP = (path, nmos = true) => {
         return Promise.reject(new Error(
           `Media type (MIME type/Content-Type) of SDP file is '${res.headers['content-type']}' and not signalled as 'applicatio/sdp' as required in RFC 4566 Section 5.`));
       } else {
-        return (nmos && !path.endsWith('.sdp')) ?
-          Promise.reject(new Error(
-            `Resource name of SDP file '${path.split('/').slice(-1)[0]}' does not end in '.sdp' as required by NMOS Section 2.3.`)) :
-          Promise.resolve(res.body);
+        return Promise.resolve(res.body);
       }
     }, e => Promise.reject(e)) :
     readFile(path, 'utf8');

--- a/sdpoker.js
+++ b/sdpoker.js
@@ -20,7 +20,6 @@ const { accessSync, R_OK } = require('fs');
 
 const args = yargs
   .help('help')
-  .default('nmos', true)
   .default('checkEndings', false)
   .default('whitespace', false)
   .default('should', false)
@@ -34,12 +33,11 @@ const args = yargs
   .default('multicast', false)
   .default('unicast', false)
   .default('shaping', false)
-  .boolean([ 'nmos', 'checkEndings', 'whitespace', 'should', 'noCopy', 'duplicate',
+  .boolean([ 'checkEndings', 'whitespace', 'should', 'noCopy', 'duplicate',
     'videoOnly', 'audioOnly', 'channelOrder',
     'useIP4', 'useIP6', 'multicast', 'unicast', 'shaping' ])
   .usage('Check an SDP file for conformance with RFC4566 and SMPTE ST 2110.\n' +
     'Usage: $0 [options] <sdp_file or HTTP URL>')
-  .describe('nmos', 'Check for compliance with NMOS rules.')
   .describe('checkEndings', 'Check line endings are CRLF, no other CR/LF.')
   .describe('whitespace', 'Strict check of adherence to whitespace rules.')
   .describe('should', 'As well as shall, also check all should clauses.')
@@ -77,7 +75,7 @@ const args = yargs
 
 async function test (args) {
   try {
-    let sdp = await getSDP(args._[0], args.nmos);
+    let sdp = await getSDP(args._[0]);
     let rfcErrors = checkRFC4566(sdp, args);
     let st2110Errors = checkST2110(sdp, args);
     let errors = rfcErrors.concat(st2110Errors);


### PR DESCRIPTION
Resolves #4

This PR removes the NMOS specific test for file extensions which is no longer applicable given the pattern used in IS-05, and updated by IS-04 v1.3.