### PR TITLE
st2110: fix bug in interlace/segmented testing

### DIFF
--- a/checkST2110.js
+++ b/checkST2110.js
@@ -663,8 +663,8 @@ const test_20_73_2 = (sdp, params) => {
       if (stream.segmented !== '') {
         errors.push(new Error(`Line ${stream._line}: For stream ${stream._streamNumber}, format parameter 'segmented' is name only, as per SMPTE ST 2110-20 Section 7.3.`));
       }
-      if (typeof stream.interlaced === 'undefined') {
-        errors.push(new Error(`Line ${stream._line}: For stream ${stream._streamNumber}, format parameter 'segmented' is signalled without 'interlaced' being signalled, as per SMPTE ST 2110-20 Section 7.3.`));
+      if (typeof stream.interlace === 'undefined') {
+        errors.push(new Error(`Line ${stream._line}: For stream ${stream._streamNumber}, format parameter 'segmented' is signalled without 'interlace' being signalled, as per SMPTE ST 2110-20 Section 7.3.`));
       }
     }
   }


### PR DESCRIPTION
This fixes a small bug in the naming of the 'interlace' parameter when testing alongside the 'segmented' parameter.