### PR TITLE
Fix some issues in test_10_82_3

### DIFF
--- a/checkST2110.js
+++ b/checkST2110.js
@@ -21,7 +21,7 @@ const mediaclkTypePattern = /[\r\n]a=mediaclk[^\s=]+/g;
 const mediaclkDirectPattern = /[\r\n]a=mediaclk:direct=\d+\s+/g;
 const sourceFilterPattern = /a=source-filter:\s(incl|excl)/;
 const tsrefclkPattern = /[\r\n]a=ts-refclk/;
-const ptpPattern = /traceable|((([0-9a-fA-F]{2}-){7}[0-9a-fA-F]{2})(:(\d+|domain-name=\S+))?)/;
+const ptpPattern = /traceable|((([0-9A-F]{2}-){7}[0-9A-F]{2})(:(\d+))?)$/;
 const macPattern = /(([0-9a-fA-F]{2}-){5}[0-9a-fA-F]{2})/;
 const dupPattern = /[\r\n]m=[\s\S]+a=ssrc-group:DUP|[\r\n]a=group:DUP[\s\S]+m=/;
 const ssrcGroupPattern = /a=ssrc-group:DUP\s+(\d+)\s+(\d+)/;
@@ -180,7 +180,7 @@ const test_10_82_3 = sdp => {
         continue; // no longer acceptable form
       }
       if (!ptpDetails.startsWith('IEEE1588-2008:')) {
-        errors.push(new Error(`Line ${x + 1}: The only supported PTP versions are 'IEEE1588-2008' and 'traceable', as per SMPTE ST 2110-10 Section 8.2.`));
+        errors.push(new Error(`Line ${x + 1}: The only supported PTP version is 'IEEE1588-2008', as per SMPTE ST 2110-10 Section 8.2.`));
         continue;
       }
       if (!ptpPattern.test(ptpDetails.slice(14))) {
@@ -188,16 +188,10 @@ const test_10_82_3 = sdp => {
         continue;
       }
       let ptpMatch = ptpDetails.slice(14).match(ptpPattern);
-      if (!ptpMatch[4] && ptpDetails.endsWith(':')) {
-        errors.push(new Error(`Line ${x + 1}: Where no PTP domain is specified, 'ptp-version' cannot end with a ':', as per RFC 7273 Section 4.8.`));
-        continue;
-      }
-      if (ptpMatch[4]) {
-        if (!ptpMatch[4].startsWith('domain-name=')) {
-          let domainNmbr = +ptpMatch[4];
-          if (domainNmbr < 0 || domainNmbr > 127) {
-            errors.push(new Error(`Line ${x + 1}: PTP domain number must be a value between 0 and 127 inclusive, as per RFC 7273 Section 4.8.`));
-          }
+      if (ptpMatch[5]) {
+        let domainNmbr = +ptpMatch[5];
+        if (domainNmbr < 0 || domainNmbr > 127) {
+          errors.push(new Error(`Line ${x + 1}: PTP domain number must be a value between 0 and 127 inclusive, as per RFC 7273 Section 4.8.`));
         }
       }
     }


### PR DESCRIPTION
I hope this fixes a few issues:

* The `ptpPattern` previously allowed lowercase hex digits, but the ABNF in RFC 7273 uses RFC 5234 `HEXDIG`, which only accepts uppercase.
* The `ptpPattern` previously accepted the pre-[RFC 7273 errata](https://www.rfc-editor.org/errata/eid4450) form for `ptp-domain-name`. (The resolution deletes the `domain-name=` prefix, similarly to the `ptp-domain-nmbr` case, which is already correct in this test.)
* However, the `ptp-domain-name` form is in any case only used for IEEE 1588-2002 (v1), not 2008 (v2), so isn't necessary for ST 2110-10.
* After the earlier update to the test to match the RFC 7273 `traceable` ABNF, the message about supported PTP versions needed updating.
 * In order to capture other unexpected extra trailing characters, I've added a `$` to the end of the regex, which means the check for `!ptpMatch[4] && ptpDetails.endsWith(':')` is no longer required since that case will be caught by the earlier one (`!ptpPattern.test(ptpDetails.slice(14))`)
* I don't believe the `domainNmbr` error could have fired before, since `ptpMatch[4]` includes the colon, so `+ptpMatch[4]` would always have been zero. I've changed this to `ptpMatch[5]`.
